### PR TITLE
Fix script typos in prank utilities

### DIFF
--- a/BADASS_LATEST-PC/dependencies/RenameUSB.ps1
+++ b/BADASS_LATEST-PC/dependencies/RenameUSB.ps1
@@ -35,7 +35,7 @@ Function get-integrity {
         }
     }
     if ($failedPaths.count -gt 0){
-        $failedPathsString = $failedPAths -join "`n"
+        $failedPathsString = $failedPaths -join "`n"
 
         $wshell = New-Object -ComObject Wscript.Shell
         $wshell.Popup("Il manque des fichiers!:`n`n$failedPathsString", 0, "Fichiers Manquants!!", 0x0)

--- a/BADASS_LATEST-PC/dependencies/data1.ps1
+++ b/BADASS_LATEST-PC/dependencies/data1.ps1
@@ -14,8 +14,8 @@ if (!$existRoot -or !$exist2) {
 } 
 
 # Copie des fichiers de son
-Copy-Item -Force $PSSCriptRoot"\"$sound1 $soundLocation2
-Copy-Item -Force $PSScriptRoot"\"$sound2 $soundLocation2
+Copy-Item -Force "$PSScriptRoot\$sound1" $soundLocation2
+Copy-Item -Force "$PSScriptRoot\$sound2" $soundLocation2
 
 # Definir le chemin vers le fichiers wav
 $wavFilePath1 = "$soundLocation2$sound1"


### PR DESCRIPTION
## Summary
- fix wrong variable name in the rename helper
- fix incorrect path in the install script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843ad3d9c148320a46b0a83595df08e