### PR TITLE
Fix variable interpolation in GUI.ps1

### DIFF
--- a/BADASS_LATEST-PC/GUI.ps1
+++ b/BADASS_LATEST-PC/GUI.ps1
@@ -59,7 +59,7 @@ function Run-Batch {
             Write-Log "$file finished successfully."    
         } else {
             $err = Get-Content temp_err.txt
-            Write-Log "Error running $file: Exit $($process.ExitCode)"
+            Write-Log "Error running ${file}: Exit $($process.ExitCode)"
             if ($err) { Write-Log $err }
         }
     } catch {


### PR DESCRIPTION
## Summary
- fix string interpolation for file variable in GUI script

## Testing
- `grep -n "Error running" -n BADASS_LATEST-PC/GUI.ps1`


------
https://chatgpt.com/codex/tasks/task_e_6843b8a71f648320837b6946dc32ee9f