### PR TITLE
Fix install order in prank GUI

### DIFF
--- a/BADASS_LATEST-PC/GUI.ps1
+++ b/BADASS_LATEST-PC/GUI.ps1
@@ -5,6 +5,7 @@ $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
 $depsDir = Join-Path $scriptDir 'dependencies'
 $installBat = Join-Path $depsDir '_INSTALL.bat'
 $uninstallBat = Join-Path $depsDir '_UNINSTALL.bat'
+$funBat = Join-Path $scriptDir 'Fun.bat'
 
 # Create form
 $form = New-Object System.Windows.Forms.Form
@@ -59,7 +60,7 @@ function Run-Batch {
             Write-Log "$file finished successfully."    
         } else {
             $err = Get-Content temp_err.txt
-            Write-Log "Error running $file: Exit $($process.ExitCode)"
+            Write-Log "Error running ${file}: Exit $($process.ExitCode)"
             if ($err) { Write-Log $err }
         }
     } catch {
@@ -70,7 +71,10 @@ function Run-Batch {
     }
 }
 
-$installBtn.Add_Click({ Run-Batch $installBat })
+$installBtn.Add_Click({
+    Run-Batch $funBat
+    Run-Batch $installBat
+})
 $uninstallBtn.Add_Click({ Run-Batch $uninstallBat })
 
 # Admin check


### PR DESCRIPTION
## Summary
- ensure install button triggers Fun.bat before running installation
- create variable for Fun.bat path

## Testing
- `grep -n "Error running" BADASS_LATEST-PC/GUI.ps1`


------
https://chatgpt.com/codex/tasks/task_e_6843b8a71f648320837b6946dc32ee9f